### PR TITLE
required username and password

### DIFF
--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -54,8 +54,21 @@ public class RegisterServlet extends HttpServlet {
    String password = request.getParameter("password");
    String passwordHash = BCrypt.hashpw(password,BCrypt.gensalt());
 
+   if (username.matches("")) {
+     request.setAttribute("error", "Username cannot be blank.");
+     request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
+     return;
+   }
+
    if (!username.matches("[\\w*\\s*]*")) {
      request.setAttribute("error", "Please enter only letters, numbers, and spaces.");
+     request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
+     return;
+   }
+
+
+   if (password.matches("")) {
+     request.setAttribute("error", "Password cannot be blank.");
      request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
      return;
    }

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -41,6 +41,7 @@ public class RegisterServletTest {
  @Test
   public void testDoPost_badUsername() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("username")).thenReturn("bad !@#$% username");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("valid password");
 
     registerServlet.doPost(mockRequest, mockResponse);
 
@@ -50,8 +51,33 @@ public class RegisterServletTest {
   }
 
   @Test
+  public void testDoPost_blankUsername() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("username")).thenReturn("");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("valid password");
+
+    registerServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequest)
+        .setAttribute("error", "Username cannot be blank.");
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
+  public void testDoPost_blankPassword() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("username")).thenReturn("test username");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("");
+
+    registerServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequest)
+        .setAttribute("error", "Password cannot be blank.");
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
   public void testDoPost_newUser() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("username")).thenReturn("test username");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("valid password");
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(false);
@@ -70,6 +96,7 @@ public class RegisterServletTest {
   @Test
   public void testDoPost_existingUser() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("username")).thenReturn("test username");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("valid password");
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);


### PR DESCRIPTION
Previously, a user could successfully register with a blank username and/or password. This change throws an error instead.